### PR TITLE
Initial support for exporting search results to data frame

### DIFF
--- a/R/CRANsearcher.R
+++ b/R/CRANsearcher.R
@@ -68,6 +68,9 @@ CRANsearcher <- function(){
     ),
     miniButtonBlock(
       div(textOutput("n"), style = "font-weight: bold")
+    ),
+    miniButtonBlock(
+      actionButton("export", "Export Filtered Results")
     )
 
   )

--- a/R/CRANsearcher.R
+++ b/R/CRANsearcher.R
@@ -252,6 +252,13 @@ CRANsearcher <- function(){
     observeEvent(input$close,{
       stopApp()
     })
+
+    observeEvent(input$export, {
+      CRANsearcher_export <<- a_sub2() %>%
+        mutate(Package = name) %>%
+        select(., -name)
+      stopApp()
+    })
   }
 
   viewer <- dialogViewer("Search packages in CRAN database based on keywords", width = 1200, height = 900)

--- a/R/CRANsearcher.R
+++ b/R/CRANsearcher.R
@@ -70,9 +70,10 @@ CRANsearcher <- function(){
       div(textOutput("n"), style = "font-weight: bold")
     ),
     miniButtonBlock(
-      actionButton("export", "Export Filtered Results")
+      shinyjs::disabled(
+        actionButton("export", "Export Filtered Results")
+      )
     )
-
   )
 
 
@@ -251,6 +252,12 @@ CRANsearcher <- function(){
 
     observeEvent(input$close,{
       stopApp()
+    })
+
+    observe({
+      if (a_sub2() != 0) {
+        shinyjs::enable("export")
+      }
     })
 
     observeEvent(input$export, {


### PR DESCRIPTION
This PR contains initial support for exporting the filtered set of package results displayed in the data table as discussed in #10.  The UI now contains an export button below the table, and it is disabled until the user completes a search of packages in the search bar.  When the user hits the button, a new data frame object called `CRANsearcher_export` is created in the user's global environment.  The data frame makes a minor change in that the `Package` column is reverted back to the character name of the package instead of the URLs for download, and the `name` column is subsequently dropped.  If you have other ideas for improving this feature I'd be glad to modify accordingly.