### PR TITLE
Prevent app crash when search produces no results

### DIFF
--- a/R/CRANsearcher.R
+++ b/R/CRANsearcher.R
@@ -148,6 +148,7 @@ CRANsearcher <- function(){
       if(identical(search_d(), character(0)) || nchar(search_d())<2){
         s <- 0
       } else{
+
         s <- a %>%
           mutate(term = tolower(paste(name, Title, Description, sep=","))) %>%
           rowwise %>%
@@ -155,6 +156,8 @@ CRANsearcher <- function(){
           filter(match==TRUE) %>%
           select(-c(term, match)) %>%
           data.frame
+
+        if (nrow(s) == 0) s <- 0
       }
       return(s)
     })
@@ -189,6 +192,9 @@ CRANsearcher <- function(){
           return()
         }
       } else{
+        validate(
+          need(a_sub2() != 0, "Your search returned no results. Please try again.")
+        )
         DT::datatable(a_sub2()[,c(1:6)],
                        rownames = FALSE,
                        escape = FALSE,
@@ -217,6 +223,9 @@ CRANsearcher <- function(){
           paste("")
         }
       } else{
+        validate(
+          need(a_sub2() != 0, "Your search returned no results. Please try again.")
+        )
         n <- dim(a_sub2())[1]
 
         if (!n==1){

--- a/R/CRANsearcher.R
+++ b/R/CRANsearcher.R
@@ -223,9 +223,7 @@ CRANsearcher <- function(){
           paste("")
         }
       } else{
-        validate(
-          need(a_sub2() != 0, "Your search returned no results. Please try again.")
-        )
+        req(a_sub2() != 0)
         n <- dim(a_sub2())[1]
 
         if (!n==1){


### PR DESCRIPTION
This PR addresses issue #12 by utilizing the `shiny::validate` function to show a message to the user in place of the data table and number of results string.  To make this work I did a simple check if 0 rows were selected based on the search criteria in the`a_sub2()` reactive data frame (if so, then I simply defined `s <- 0`).  Happy to make any tweaks if you would like to see a different message appear to the user. 